### PR TITLE
Fix args in poke method.

### DIFF
--- a/ts3/commands.py
+++ b/ts3/commands.py
@@ -1504,7 +1504,7 @@ class TS3Commands(object):
             options.append("permsid")
         return self._return_proxy("clientpermlist", cparams, uparams, options)
         
-    def clientpoke(self, *, msg, clid):
+    def clientpoke(self, msg, clid):
         """
         Usage::
 


### PR DESCRIPTION
Argument problem found in "poke" method via the Example "Say hello to all clients". Removed "*," from the arguments.
