### PR TITLE
Removal of assertion

### DIFF
--- a/ts3/query.py
+++ b/ts3/query.py
@@ -290,8 +290,6 @@ class TS3BaseConnection(object):
                 if not data:
                     raise TS3TimeoutError()
                 elif data.startswith(b"notify"):
-                    assert not self._telnet_queue
-
                     event = TS3Event(data)
                     self._event_queue.append(event)
                     return event


### PR DESCRIPTION
Removal of the assert line,  as TS3 Servers love to send multiple things at once.

Should fix #37

A somewhat more descriptive text why I'm removing that line is here: http://forum.teamspeak.com/threads/130961-Channel-ownership-serverquery-temporary-channel-creation