### PR TITLE
Fix for 'serversnapshotdeploy' command

### DIFF
--- a/ts3/commands.py
+++ b/ts3/commands.py
@@ -25,6 +25,7 @@
 # Modules
 # ------------------------------------------------
 from collections import OrderedDict
+from .escape import RawParameter
 
 
 # Data
@@ -3787,7 +3788,7 @@ class TS3Commands(object):
         uparams = list()
         options = list()
 
-        cparams[""] = virtualserver_snapshot
+        cparams[""] = RawParameter(virtualserver_snapshot)
         return self._return_proxy("serversnapshotdeploy", cparams, uparams, options)
 
     def serverstart(self, *, sid):


### PR DESCRIPTION
Fix for #49 

* omits '=' in `escape_parameters` if the key is empty
* adds a class `RawCommand`, which can be used to prevent the escaping of a parameter 