### PR TITLE
Add 'client_nickname' optional parameter to 'use' command

### DIFF
--- a/ts3/commands.py
+++ b/ts3/commands.py
@@ -4092,12 +4092,12 @@ class TS3Commands(object):
         cparams["token"] = token
         return self._return_proxy("tokenuse", cparams, uparams, options)
 
-    def use(self, *, sid=None, port=None, virtual=False):
+    def use(self, *, sid=None, port=None, client_nickname=None, virtual=False):
         """
         Usage::
 
-            use [sid={serverID}] [port={serverPort}] [-virtual]
-            use {serverID}
+            use [sid={serverID}] [port={serverPort}] [-virtual] [client_nickname={nickname}]
+            use {serverID} [-virtual] [client_nickname={nickname}]
 
         Selects the virtual server specified with sid or port to allow further
         interaction. The ServerQuery client will appear on the virtual server
@@ -4124,6 +4124,7 @@ class TS3Commands(object):
 
         cparams["sid"] = sid
         cparams["port"] = port
+        cparams["client_nickname"] = client_nickname
 
         if virtual:
             options.append("virtual")


### PR DESCRIPTION
Teamspeak has added a _client_nickname_ parameter to its _use_ command, which seems to be required on some servers, although I was not able to replicate the required circumstances. I have added this capability to the respective method in the command class.